### PR TITLE
Extend `<FullscreenNav />` Component to Include `footerLogo` Prop

### DIFF
--- a/src/FullscreenNav/index.tsx
+++ b/src/FullscreenNav/index.tsx
@@ -23,6 +23,7 @@ import {
   StyledDetails,
   StyledSummary,
   StyledFooter,
+  StyledFooterLogoImage,
 } from "./styles";
 
 interface IFNavSection {
@@ -44,6 +45,8 @@ interface IFNav {
   navigation: IFNavigation;
   logoutPath: string;
   logoutTitle: string;
+  footerLabel?: string;
+  footerLogo?: string;
 }
 
 const MultiSections = ({ navigation }: IFNav) => {
@@ -193,7 +196,14 @@ const sectionsComponents: {
 const FullscreenMenu = (
   props: Omit<IFNav, "portalId"> & { onClose: () => void },
 ) => {
-  const { navigation, logoutTitle, logoutPath, onClose } = props;
+  const {
+    navigation,
+    logoutTitle,
+    logoutPath,
+    onClose,
+    footerLabel = "©2024 - Inube",
+    footerLogo,
+  } = props;
   const theme: typeof inube = useContext(ThemeContext);
   const titleFullscreenNavAppearance =
     (theme?.fullscreenNav?.title?.appearance as ITextAppearance) ||
@@ -236,21 +246,34 @@ const FullscreenMenu = (
         path={logoutPath}
       />
       <StyledFooter>
-        <Text
-          type="label"
-          size="medium"
-          appearance={fullscreenNavCopyrightAppearance}
-          weight="bold"
-        >
-          ©2023 - Inube
-        </Text>
+        <Stack justifyContent="center" alignItems="center">
+          {footerLogo ? (
+            <StyledFooterLogoImage src={footerLogo} alt="" />
+          ) : (
+            <Text
+              type="label"
+              size="medium"
+              appearance={fullscreenNavCopyrightAppearance}
+              weight="bold"
+            >
+              {footerLabel}
+            </Text>
+          )}
+        </Stack>
       </StyledFooter>
     </StyledFullscreenNav>
   );
 };
 
 const FullscreenNav = (props: IFNav) => {
-  const { portalId, navigation, logoutTitle, logoutPath } = props;
+  const {
+    portalId,
+    navigation,
+    logoutTitle,
+    logoutPath,
+    footerLabel,
+    footerLogo,
+  } = props;
   const [isMenuOpen, setIsMenuOpen] = useState(false);
   const theme: typeof inube = useContext(ThemeContext);
   const fullscreenNavBurgerIconAppearance =
@@ -281,6 +304,8 @@ const FullscreenNav = (props: IFNav) => {
             navigation={navigation}
             logoutPath={logoutPath}
             logoutTitle={logoutTitle}
+            footerLabel={footerLabel}
+            footerLogo={footerLogo}
             onClose={() => setIsMenuOpen(false)}
           />,
           node,

--- a/src/FullscreenNav/stories/FullscreenNav.WithLogo.stories.tsx
+++ b/src/FullscreenNav/stories/FullscreenNav.WithLogo.stories.tsx
@@ -1,0 +1,102 @@
+import { BrowserRouter } from "react-router-dom";
+import {
+  MdVpnKey,
+  MdMeetingRoom,
+  MdContacts,
+  MdStarBorder,
+  MdBadge,
+  MdAccountBalanceWallet,
+  MdAccountBalance,
+} from "react-icons/md";
+
+import { FullscreenNav, IFNav } from "..";
+
+import { props } from "../props";
+
+const story = {
+  title: "navigation/FullscreenNav",
+  components: [FullscreenNav],
+  argTypes: props,
+  decorators: [
+    (Story: React.ElementType) => (
+      <BrowserRouter>
+        <Story />
+      </BrowserRouter>
+    ),
+  ],
+};
+
+const WithLogo = (args: IFNav) => <FullscreenNav {...args} />;
+
+WithLogo.args = {
+  portalId: "portals",
+  navigation: {
+    title: "MENU",
+    sections: {
+      administrative: {
+        name: "Administrative",
+        links: {
+          privileges: {
+            id: "privileges",
+            label: "Privileges",
+            icon: <MdVpnKey />,
+            path: "/privileges",
+          },
+          accounting: {
+            id: "accounting",
+            label: "Accounting",
+            icon: <MdMeetingRoom />,
+            path: "/accounting",
+          },
+          contacts: {
+            id: "contacts",
+            label: "Contacts",
+            icon: <MdContacts />,
+            path: "/contacts",
+          },
+          crm: {
+            id: "crm",
+            label: "CRM",
+            icon: <MdStarBorder />,
+            path: "/crm",
+          },
+        },
+      },
+      request: {
+        name: "Request",
+        links: {
+          documents: {
+            id: "documents",
+            label: "Documents",
+            icon: <MdBadge />,
+            path: "/documents",
+          },
+          marketing: {
+            id: "marketing",
+            label: "Marketing",
+            icon: <MdStarBorder />,
+            path: "/marketing",
+          },
+          savings: {
+            id: "savings",
+            label: "Savings",
+            icon: <MdAccountBalanceWallet />,
+            path: "/savings",
+          },
+          credit: {
+            id: "credit",
+            label: "Credit",
+            icon: <MdAccountBalance />,
+            path: "/credit",
+          },
+        },
+      },
+    },
+  },
+  logoutPath: "/logout",
+  logoutTitle: "logout",
+  footerLogo: "https://i.imgur.com/YYrs6cF.png",
+};
+
+export default story;
+export { WithLogo };

--- a/src/FullscreenNav/styles.js
+++ b/src/FullscreenNav/styles.js
@@ -63,11 +63,20 @@ const StyledSummary = styled.summary`
       inube.fullscreenNav.background.color};
   }
 `;
+
+const StyledFooterLogoImage = styled.img`
+  width: 124px;
+  height: auto;
+  display: block;
+  padding: 24px 62px;
+`;
+
 export {
   StyledContDropMenu,
   StyledFullscreenNav,
   StyledSeparatorLine,
   StyledFooter,
+  StyledFooterLogoImage,
   StyledDetails,
   StyledSummary,
 };


### PR DESCRIPTION
This pull request extends the `<FullscreenNav />` component by adding a new optional `footerLogo` prop. This enhancement allows developers to customize the footer of the full-screen navigation with an image logo, providing greater flexibility in design and branding.