### PR TITLE
Move fullscreennav tokens from foundations to component

### DIFF
--- a/src/FullscreenNav/Tokens/tokens.ts
+++ b/src/FullscreenNav/Tokens/tokens.ts
@@ -1,0 +1,40 @@
+import { inube } from "@inubekit/foundations";
+
+const tokens = {
+  background: {
+    color: inube.palette.neutral.N10,
+  },
+  divider: {
+    color: inube.palette.neutral.N40,
+  },
+  title: {
+    appearance: "gray",
+  },
+  subtitle: {
+    appearance: {
+      regular: "gray",
+      expanded: "primary",
+    },
+    background: {
+      expanded: inube.palette.neutral.N30,
+    },
+  },
+  link: {
+    appearance: {
+      regular: "dark",
+      selected: "primary",
+    },
+    background: {
+      selected: inube.palette.neutral.N30,
+      hover: inube.palette.neutral.N30,
+    },
+  },
+  copyright: {
+    appearance: "gray",
+  },
+  burger: {
+    appearance: "dark",
+  },
+};
+
+export { tokens };

--- a/src/FullscreenNav/index.tsx
+++ b/src/FullscreenNav/index.tsx
@@ -15,7 +15,6 @@ import { Stack } from "@inubekit/stack";
 import { NavLink, INavLink } from "@inubekit/nav";
 import { useContext } from "react";
 import { ThemeContext } from "styled-components";
-import { inube } from "@inubekit/foundations";
 import {
   StyledContDropMenu,
   StyledFullscreenNav,
@@ -25,6 +24,7 @@ import {
   StyledFooter,
   StyledFooterLogoImage,
 } from "./styles";
+import { tokens } from "./Tokens/tokens";
 
 interface IFNavSection {
   name: string;
@@ -51,13 +51,13 @@ interface IFNav {
 
 const MultiSections = ({ navigation }: IFNav) => {
   const sections = Object.keys(navigation.sections);
-  const theme: typeof inube = useContext(ThemeContext);
+  const theme = useContext(ThemeContext) as { fullscreenNav: typeof tokens };
   const selectedNavLinkAppearance =
     (theme?.fullscreenNav?.link?.appearance?.selected as IIconAppearance) ||
-    inube.fullscreenNav.link.appearance.selected;
+    tokens.link.appearance.selected;
   const regularNavLinkAppearance =
     (theme?.fullscreenNav?.link?.appearance?.regular as IIconAppearance) ||
-    inube.fullscreenNav.link.appearance.regular;
+    tokens.link.appearance.regular;
   const [openSection, setOpenSection] = useState<string | null>(null);
 
   const toggleSection = (section: string) => {
@@ -131,10 +131,10 @@ const MultiSections = ({ navigation }: IFNav) => {
 
 const TwoSections = ({ navigation }: IFNavMenuSection) => {
   const navigationSectionValues = Object.values(navigation.sections);
-  const theme: typeof inube = useContext(ThemeContext);
+  const theme = useContext(ThemeContext) as { fullscreenNav: typeof tokens };
   const titleAppearance =
     (theme?.fullscreenNav?.title?.appearance as ITextAppearance) ||
-    inube.fullscreenNav.title.appearance;
+    tokens.title.appearance;
   return (
     <Stack direction="column">
       {navigationSectionValues.map((sectionValue) => (
@@ -204,16 +204,16 @@ const FullscreenMenu = (
     footerLabel = "©2024 - Inube",
     footerLogo,
   } = props;
-  const theme: typeof inube = useContext(ThemeContext);
+  const theme = useContext(ThemeContext) as { fullscreenNav: typeof tokens };
   const titleFullscreenNavAppearance =
     (theme?.fullscreenNav?.title?.appearance as ITextAppearance) ||
-    inube.fullscreenNav.title.appearance;
+    tokens.title.appearance;
   const fullscreenNavCopyrightAppearance =
     (theme?.fullscreenNav?.copyright?.appearance as ITextAppearance) ||
-    inube.fullscreenNav.copyright.appearance;
+    tokens.copyright.appearance;
   const fullscreenNavCloseIconAppearance =
     (theme?.fullscreenNav?.burger?.appearance as IIconAppearance) ||
-    inube.fullscreenNav.burger.appearance;
+    tokens.burger.appearance;
   const sections = Object.keys(navigation.sections);
   const SectionComponent =
     sectionsComponents[sections.length] || sectionsComponents.default;
@@ -275,10 +275,10 @@ const FullscreenNav = (props: IFNav) => {
     footerLogo,
   } = props;
   const [isMenuOpen, setIsMenuOpen] = useState(false);
-  const theme: typeof inube = useContext(ThemeContext);
+  const theme = useContext(ThemeContext) as { fullscreenNav: typeof tokens };
   const fullscreenNavBurgerIconAppearance =
     (theme?.fullscreenNav?.burger?.appearance as IIconAppearance) ||
-    inube.fullscreenNav.burger.appearance;
+    tokens.burger.appearance;
   const node = document.getElementById(portalId);
 
   if (node === null) {

--- a/src/FullscreenNav/styles.js
+++ b/src/FullscreenNav/styles.js
@@ -1,5 +1,5 @@
 import styled from "styled-components";
-import { inube } from "@inubekit/foundations";
+import { tokens } from "./Tokens/tokens";
 
 const StyledContDropMenu = styled.div`
   position: absolute;
@@ -18,8 +18,7 @@ const StyledFullscreenNav = styled.nav`
   bottom: 0;
   left: 0;
   background-color: ${({ theme }) =>
-    theme?.fullscreenNav?.background?.color ||
-    inube.fullscreenNav.background.color};
+    theme?.fullscreenNav?.background?.color || tokens.background.color};
   padding: 0px 16px;
   z-index: 2;
   overflow-y: auto;
@@ -32,7 +31,7 @@ const StyledSeparatorLine = styled.div`
   margin: 16px 16px 16px;
   height: 1px;
   background-color: ${({ theme }) =>
-    theme?.fullscreenNav?.divider?.color || inube.fullscreenNav.divider.color};
+    theme?.fullscreenNav?.divider?.color || tokens.divider.color};
 `;
 
 const StyledFooter = styled.footer`
@@ -59,8 +58,7 @@ const StyledSummary = styled.summary`
   &:hover {
     cursor: pointer;
     background-color: ${({ theme }) =>
-      theme?.fullscreenNav?.background?.color ||
-      inube.fullscreenNav.background.color};
+      theme?.fullscreenNav?.background?.color || tokens.background.color};
   }
 `;
 


### PR DESCRIPTION
This PR relocates the fullscreennav tokens from the foundations folder to the component folder, updating all necessary imports to reflect the new structure and ensuring that components are referencing the correct token paths. This refactor enhances the organization, maintainability, and clarity of the codebase.