### PR TITLE
Refactor FullscreenNav to replace logout props with actions prop

### DIFF
--- a/package.json
+++ b/package.json
@@ -43,7 +43,7 @@
     "@inubekit/foundations": "^5.11.3",
     "@inubekit/grid": "^2.3.0",
     "@inubekit/icon": "^2.17.0",
-    "@inubekit/nav": "^4.6.0",
+    "@inubekit/nav": "^5.0.0",
     "@inubekit/stack": "^3.8.0",
     "@inubekit/text": "^2.17.0"
   },

--- a/src/FullscreenNav/index.tsx
+++ b/src/FullscreenNav/index.tsx
@@ -3,7 +3,6 @@ import { createPortal } from "react-dom";
 import {
   MdMenu,
   MdClose,
-  MdLogout,
   MdOutlineArrowDropDown,
   MdOutlineArrowDropUp,
 } from "react-icons/md";
@@ -12,7 +11,7 @@ import { Icon, IIconAppearance } from "@inubekit/icon";
 import { ITextAppearance, Text } from "@inubekit/text";
 import { Grid } from "@inubekit/grid";
 import { Stack } from "@inubekit/stack";
-import { NavLink, INavLink } from "@inubekit/nav";
+import { NavLink, INavLink, INavAction } from "@inubekit/nav";
 import { useContext } from "react";
 import { ThemeContext } from "styled-components";
 import {
@@ -43,8 +42,7 @@ interface IFNavigation {
 interface IFNav {
   portalId: string;
   navigation: IFNavigation;
-  logoutPath: string;
-  logoutTitle: string;
+  actions?: INavAction[];
   footerLabel?: string;
   footerLogo?: string;
 }
@@ -117,7 +115,7 @@ const MultiSections = ({ navigation }: IFNav) => {
                     label={linkValue.label}
                     icon={linkValue.icon}
                     path={linkValue.path}
-                    onClick={(e: PointerEvent) => e.stopPropagation()}
+                    onClick={(e) => e.stopPropagation()}
                   />
                 ),
               )}
@@ -198,8 +196,7 @@ const FullscreenMenu = (
 ) => {
   const {
     navigation,
-    logoutTitle,
-    logoutPath,
+    actions,
     onClose,
     footerLabel = "©2024 - Inube",
     footerLogo,
@@ -239,12 +236,19 @@ const FullscreenMenu = (
       </Grid>
       <SectionComponent navigation={navigation} />
       <StyledSeparatorLine />
-      <NavLink
-        id="logoutPath"
-        label={logoutTitle}
-        icon={<MdLogout />}
-        path={logoutPath}
-      />
+      {actions && actions.length > 0 && (
+        <>
+          {actions.map(({ id, label, icon, action }) => (
+            <NavLink
+              key={id}
+              id={id}
+              label={label}
+              icon={icon}
+              onClick={action}
+            />
+          ))}
+        </>
+      )}
       <StyledFooter>
         <Stack justifyContent="center" alignItems="center">
           {footerLogo ? (
@@ -266,14 +270,7 @@ const FullscreenMenu = (
 };
 
 const FullscreenNav = (props: IFNav) => {
-  const {
-    portalId,
-    navigation,
-    logoutTitle,
-    logoutPath,
-    footerLabel,
-    footerLogo,
-  } = props;
+  const { portalId, navigation, actions, footerLabel, footerLogo } = props;
   const [isMenuOpen, setIsMenuOpen] = useState(false);
   const theme = useContext(ThemeContext) as { fullscreenNav: typeof tokens };
   const fullscreenNavBurgerIconAppearance =
@@ -302,8 +299,7 @@ const FullscreenNav = (props: IFNav) => {
         createPortal(
           <FullscreenMenu
             navigation={navigation}
-            logoutPath={logoutPath}
-            logoutTitle={logoutTitle}
+            actions={actions}
             footerLabel={footerLabel}
             footerLogo={footerLogo}
             onClose={() => setIsMenuOpen(false)}

--- a/src/FullscreenNav/stories/FullscreenNav.MultiSections.stories.tsx
+++ b/src/FullscreenNav/stories/FullscreenNav.MultiSections.stories.tsx
@@ -11,6 +11,7 @@ import {
   MdAutorenew,
   MdPriceChange,
   MdSecurityUpdateGood,
+  MdLogout,
 } from "react-icons/md";
 
 import { FullscreenNav, IFNav } from "..";
@@ -126,8 +127,20 @@ Multisections.args = {
       },
     },
   },
-  logoutPath: "/logout",
-  logoutTitle: "logout",
+  actions: [
+    {
+      id: "action1",
+      label: "Action 1",
+      icon: <MdLogout />,
+      action: () => console.log("Action 1 triggered"),
+    },
+    {
+      id: "action2",
+      label: "Action 2",
+      icon: <MdLogout />,
+      action: () => console.log("Action 2 triggered"),
+    },
+  ],
 };
 
 export default story;

--- a/src/FullscreenNav/stories/FullscreenNav.WithLogo.stories.tsx
+++ b/src/FullscreenNav/stories/FullscreenNav.WithLogo.stories.tsx
@@ -7,6 +7,7 @@ import {
   MdBadge,
   MdAccountBalanceWallet,
   MdAccountBalance,
+  MdLogout,
 } from "react-icons/md";
 
 import { FullscreenNav, IFNav } from "..";
@@ -93,8 +94,20 @@ WithLogo.args = {
       },
     },
   },
-  logoutPath: "/logout",
-  logoutTitle: "logout",
+  actions: [
+    {
+      id: "action1",
+      label: "Action 1",
+      icon: <MdLogout />,
+      action: () => console.log("Action 1 triggered"),
+    },
+    {
+      id: "action2",
+      label: "Action 2",
+      icon: <MdLogout />,
+      action: () => console.log("Action 2 triggered"),
+    },
+  ],
   footerLogo: "https://i.imgur.com/YYrs6cF.png",
 };
 

--- a/src/FullscreenNav/stories/FullscreenNav.WithoutSections.stories.tsx
+++ b/src/FullscreenNav/stories/FullscreenNav.WithoutSections.stories.tsx
@@ -8,6 +8,7 @@ import {
   MdStarBorder,
   MdAccountBalance,
   MdAccountBalanceWallet,
+  MdLogout,
 } from "react-icons/md";
 
 import { FullscreenNav, IFNav } from "..";
@@ -82,8 +83,20 @@ WithoutSections.args = {
       },
     },
   },
-  logoutPath: "/logout",
-  logoutTitle: "logout",
+  actions: [
+    {
+      id: "action1",
+      label: "Action 1",
+      icon: <MdLogout />,
+      action: () => console.log("Action 1 triggered"),
+    },
+    {
+      id: "action2",
+      label: "Action 2",
+      icon: <MdLogout />,
+      action: () => console.log("Action 2 triggered"),
+    },
+  ],
 };
 
 export default story;

--- a/src/FullscreenNav/stories/FullscreenNav.stories.tsx
+++ b/src/FullscreenNav/stories/FullscreenNav.stories.tsx
@@ -7,6 +7,7 @@ import {
   MdBadge,
   MdAccountBalanceWallet,
   MdAccountBalance,
+  MdLogout,
 } from "react-icons/md";
 
 import { FullscreenNav, IFNav } from "..";
@@ -93,8 +94,20 @@ Default.args = {
       },
     },
   },
-  logoutPath: "/logout",
-  logoutTitle: "logout",
+  actions: [
+    {
+      id: "action1",
+      label: "Action 1",
+      icon: <MdLogout />,
+      action: () => console.log("Action 1 triggered"),
+    },
+    {
+      id: "action2",
+      label: "Action 2",
+      icon: <MdLogout />,
+      action: () => console.log("Action 2 triggered"),
+    },
+  ],
 };
 
 export default story;

--- a/src/FullscreenNav/styles.js
+++ b/src/FullscreenNav/styles.js
@@ -24,6 +24,9 @@ const StyledFullscreenNav = styled.nav`
   overflow-y: auto;
   overflow-x: hidden;
   -webkit-overflow-scrolling: touch;
+  & > li {
+    cursor: pointer;
+  }
 `;
 
 const StyledSeparatorLine = styled.div`


### PR DESCRIPTION
This PR refactors the FullscreenNav component by removing the logoutTitle and logoutPath props and replacing them with an actions prop. The actions prop accepts an array of action objects, allowing multiple actions to be passed and rendered below the divider. Each action triggers its respective function without navigation. The changes also include updates to the FullscreenMenu and related components to ensure consistency and improve code maintainability. The portal rendering logic remains intact, and the footer section has been adjusted to handle the new structure. This refactor enhances flexibility by allowing more dynamic actions within the FullscreenNav.